### PR TITLE
詳細画面のUIを改善

### DIFF
--- a/lib/screens/repository_detail_screen.dart
+++ b/lib/screens/repository_detail_screen.dart
@@ -11,6 +11,15 @@ class RepositoryDetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // 表示するラベルと値をリストで管理
+    final repositoryDetails = [
+      {"label": "言語", "value": repository.language},
+      {"label": "スター数", "value": repository.stars.toString()},
+      {"label": "ウォッチャー数", "value": repository.watchers.toString()},
+      {"label": "フォーク数", "value": repository.forks.toString()},
+      {"label": "未解決の課題", "value": repository.openIssues.toString()},
+    ];
+
     return Scaffold(
       appBar: AppBar(title: Text(repository.name)),
       body: Padding(
@@ -22,16 +31,14 @@ class RepositoryDetailScreen extends StatelessWidget {
                 radius: 50,
                 backgroundImage: NetworkImage(repository.ownerAvatarUrl),
               ),
-              SizedBox(height: 10),
-              _buildDetailRow("言語", repository.language),
-              SizedBox(height: 10),
-              _buildDetailRow("スター数", repository.stars.toString()),
-              SizedBox(height: 10),
-              _buildDetailRow("ウォッチャー数", repository.watchers.toString()),
-              SizedBox(height: 10),
-              _buildDetailRow("フォーク数", repository.forks.toString()),
-              SizedBox(height: 10),
-              _buildDetailRow("未解決の課題", repository.openIssues.toString()),
+              SizedBox(height: 20),
+              // リストを動的にウィジェットに変換
+              ...repositoryDetails.map((detailItem) => Column(
+                    children: [
+                      _buildDetailRow(detailItem["label"]!, detailItem["value"]!),
+                      SizedBox(height: 10),
+                    ],
+              )),
             ],
           ),
         ),
@@ -39,7 +46,7 @@ class RepositoryDetailScreen extends StatelessWidget {
     );
   }
 
-  /// ラベルと値を揃えて表示する行を構築するヘルパーメソッド
+  /// ラベルと値を揃えて表示する行を構築するメソッド
   Widget _buildDetailRow(String label, String value) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/screens/repository_detail_screen.dart
+++ b/lib/screens/repository_detail_screen.dart
@@ -15,21 +15,44 @@ class RepositoryDetailScreen extends StatelessWidget {
       appBar: AppBar(title: Text(repository.name)),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
-        child: Column(
-          children: [
-            CircleAvatar(
-              radius: 50,
-              backgroundImage: NetworkImage(repository.ownerAvatarUrl),
-            ),
-            SizedBox(height: 20),
-            Text("Language: ${repository.language}"),
-            Text("Stars: ${repository.stars}"),
-            Text("Watchers: ${repository.watchers}"),
-            Text("Forks: ${repository.forks}"),
-            Text("Open Issues: ${repository.openIssues}"),
-          ],
+        child: Center(
+          child: Column(
+            children: [
+              CircleAvatar(
+                radius: 50,
+                backgroundImage: NetworkImage(repository.ownerAvatarUrl),
+              ),
+              SizedBox(height: 10),
+              _buildDetailRow("言語", repository.language),
+              SizedBox(height: 10),
+              _buildDetailRow("スター数", repository.stars.toString()),
+              SizedBox(height: 10),
+              _buildDetailRow("ウォッチャー数", repository.watchers.toString()),
+              SizedBox(height: 10),
+              _buildDetailRow("フォーク数", repository.forks.toString()),
+              SizedBox(height: 10),
+              _buildDetailRow("未解決の課題", repository.openIssues.toString()),
+            ],
+          ),
         ),
       ),
+    );
+  }
+
+  /// ラベルと値を揃えて表示する行を構築するヘルパーメソッド
+  Widget _buildDetailRow(String label, String value) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          label,
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        Text(
+          value,
+          style: TextStyle(fontSize: 18),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## 変更理由
- 詳細画面に表示される文字やアバターが見づらかったため、変更した

## 詳細画面のUIを以下のように改善しました
- オーナーのアバター画像を真ん中に表示
- リポジトリの詳細情報（言語、スター数、ウォッチャー数など）の列を整え、見やすく表示

## 具体的な変更内容
- `repository_detail_screen.dart` のUIを改善

## 確認方法
1. アプリを起動
2. リポジトリ詳細画面に遷移
3. 各情報が正しく表示されることを確認

### 関連Issue
なし
