### PR TITLE
横向き表示時のレイアウトを改善

### DIFF
--- a/lib/screens/repository_detail_screen.dart
+++ b/lib/screens/repository_detail_screen.dart
@@ -10,6 +10,9 @@ class RepositoryDetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final deviceWidth = MediaQuery.of(context).size.width;
+    const double sideMargin = 30.0;
+
     // 表示するテキストと値をリストで管理
     final repositoryDetails = [
       {"label": "言語",         "value": repository.language},
@@ -21,26 +24,44 @@ class RepositoryDetailScreen extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(title: Text(repository.name)),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Center(
-          child: Column(
-            children: [
-              CircleAvatar(
-                radius: 50,
-                backgroundImage: NetworkImage(repository.ownerAvatarUrl),
-              ),
-              SizedBox(height: 20),
-              // リストを動的にウィジェットに変換
-              ...repositoryDetails.map((detailItem) => Column(
+      body: OrientationBuilder(
+        builder: (context, orientation) {
+          final landscapeMaxWidth = deviceWidth - (sideMargin * 2);
+
+          return Center(
+            child: Container(
+              //画面の向きが横なら、左右のマージンを考慮して最大幅を設定
+              constraints: orientation == Orientation.portrait
+                  ? null
+                  : BoxConstraints(maxWidth: landscapeMaxWidth),
+
+              child: SingleChildScrollView(
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Column(
                     children: [
-                      _buildDetailRow(detailItem["label"]!, detailItem["value"]!),
-                      SizedBox(height: 10),
+                      CircleAvatar(
+                        radius: 50,
+                        backgroundImage:NetworkImage(repository.ownerAvatarUrl),
+                      ),
+
+                      // repositoryDetailsリストの各項目を「詳細行 + 下部スペース」の Column に変換して展開
+                      for (var detailItem in repositoryDetails)
+                        Column(
+                          children: [
+                            _buildDetailRow(
+                                detailItem["label"]!, detailItem["value"]!),
+                            const SizedBox(height: 10),
+                          ],
+                        ),
                     ],
-              )),
-            ],
-          ),
-        ),
+                  ),
+                ),
+              ),
+
+            ),
+          );
+        },
       ),
     );
   }
@@ -50,8 +71,8 @@ class RepositoryDetailScreen extends StatelessWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        Text(label,style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-        Text(value,style: TextStyle(fontSize: 18)),
+        Text(label, style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+        Text(value, style: TextStyle(fontSize: 18)),
       ],
     );
   }

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -3,11 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:yumemi_coding_test/utils/repository_sorter.dart';
 import 'package:yumemi_coding_test/services/github_api_service.dart';
 import 'package:yumemi_coding_test/models/repository.dart';
+import 'package:yumemi_coding_test/widgets/search_controls.dart';
+import 'package:yumemi_coding_test/widgets/search_result_view.dart';
 import 'package:yumemi_coding_test/widgets/theme_selection_bottom_sheet.dart';
-import 'package:yumemi_coding_test/widgets/empty_result.dart';
-import 'package:yumemi_coding_test/widgets/repository_card.dart';
-import 'package:yumemi_coding_test/widgets/sort_option.dart';
-
 
 /// リポジトリ検索画面の状態を管理するクラス。
 /// ユーザー入力、検索結果リスト、ソート状態の保持、API呼び出し、UI更新を行う。
@@ -23,10 +21,10 @@ class SearchScreenState extends State<SearchScreen> {
   List<Repository> _repositoryList = [];
   final _isSortAscending = false;
   final _currentSortOption = 'stars';
+    final gitHubApiService = GitHubApiService();
 
   /// リポジトリの検索を実行するメソッド
   void _searchRepositories() async {
-    final gitHubApiService = GitHubApiService();
     final repositoryName = _userInput.text;
     if (repositoryName.isNotEmpty) {
       final fetchedRepositories =
@@ -36,85 +34,105 @@ class SearchScreenState extends State<SearchScreen> {
       });
     }
   }
-  
 
   /// ユーザが指定したソート条件を適用するメソッド
   void _sortRepositories(String sortOption, bool isSortAscending) {
     setState(() {
+      
       RepositorySorter.sortRepositories(
           _repositoryList, sortOption, isSortAscending);
     });
   }
-
 
   /// テーマ選択用のボトムシートを表示するメソッド
   void _showThemeBottomSheet(BuildContext context) {
     showModalBottomSheet<void>(
       context: context,
       builder: (BuildContext context) {
-        return const ThemeSelectionBottomSheet(); 
+        return const ThemeSelectionBottomSheet();
       },
     );
   }
 
-  
+
 
   @override
   Widget build(BuildContext context) {
+    final deviceWidth = MediaQuery.of(context).size.width;
+    final deviceOrientation = MediaQuery.of(context).orientation;
+
+    const double sideMargin = 40.0;
 
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       appBar: AppBar(
-        title: Text("GitHub リポジトリ検索"),
+        title: const Text("GitHub リポジトリ検索"),
         actions: [
-          IconButton(
-            icon: Icon(Icons.settings), // アイコンを元に戻す (または settings のまま)
-            tooltip: 'テーマを変更',
-            onPressed: () {
-              _showThemeBottomSheet(context);
-            },
+          Padding(
+
+            // 横向きの場合、右側にマージンを追加
+            padding: EdgeInsets.only(
+              right: deviceOrientation == Orientation.landscape ? 40.0 : 0,
+            ),
+
+            child: IconButton(
+              icon: const Icon(Icons.settings),
+              tooltip: 'テーマを変更',
+              onPressed: () {
+                _showThemeBottomSheet(context);
+              },
+            ),
           ),
         ],
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: Column(
-          children: [
-            TextField(
-              controller: _userInput,
-              decoration: InputDecoration(labelText: "リポジトリ名で検索"),
-            ),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Spacer(flex: 3),
-                ElevatedButton(
-                  onPressed: _searchRepositories,
-                  child: Text("検索"),
-                ),
-                Spacer(flex: 2),
-                SortDropdown(
-                  onSortSelected: (String sortOption, bool isSortAscending) {
-                    _sortRepositories(sortOption, isSortAscending);
-                  },
-                  isSortAscending: _isSortAscending,
-                  currentSortOption: _currentSortOption,
-                ),
-              ],
-            ),
-            Expanded(
-              child: _repositoryList.isEmpty
-                  ? const EmptyResultWidget()
-                  : ListView.builder(
-                      itemCount: _repositoryList.length,
-                      itemBuilder: (context, index) {
-                        return RepositoryCard(
-                            repository: _repositoryList[index]);
-                      },
+      body: OrientationBuilder(
+        builder: (context, orientation) {
+          final portraitOrientation = orientation == Orientation.portrait;
+          final landscapeMaxWidth = deviceWidth - (sideMargin * 2);
+
+          return Center(
+            child: Container(
+
+              //画面の向きが横なら、左右のマージンを考慮して最大幅を設定
+              constraints: portraitOrientation
+                  ? null
+                  : BoxConstraints(maxWidth: landscapeMaxWidth),
+
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Column(
+                  children: [
+
+                    // 検索入力、ボタン、ソートを含むコントロール部分
+                    SearchControls(
+                      userInputController: _userInput,
+                      onSearchPressed: _searchRepositories,
+                      onSortSelected: _sortRepositories,
+                      isSortAscending: _isSortAscending,
+                      currentSortOption: _currentSortOption,
+                      portraitOrientation: portraitOrientation,
                     ),
+                    const SizedBox(height: 16),
+
+                    // 検索結果リストまたはメッセージを表示
+                    Expanded(
+                      child: SearchResultView(repositoryList: _repositoryList),
+                    ),
+
+                  ],
+                ),
+              ),
             ),
-          ],
-        ),
+          );
+        },
       ),
     );
+  }
+
+  ///メモリリークや不要な処理の継続を防ぐ
+  @override
+  void dispose() {
+    _userInput.dispose();
+    super.dispose();
   }
 }

--- a/lib/widgets/empty_result.dart
+++ b/lib/widgets/empty_result.dart
@@ -4,28 +4,82 @@ import 'package:flutter/material.dart';
 class EmptyResultWidget extends StatelessWidget {
   const EmptyResultWidget({super.key});
 
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+  // 定数定義
+  static const double _padding = 16.0;
+  static const double _landscapeSpacing = 24.0;
+  static const double _portraitImageSize = 300.0;
+  static const double _landscapeImageSize = 150.0;
+  static const String _message = "該当するリポジトリが見つかりませんでした。\n"
+                                "別のキーワードで試してみてください！";
+
+
+
+  /// 縦向きレイアウト構築メソッド
+  Widget _buildPortraitLayout(
+      Widget messageText, Widget Function(double) imageWidget) {
+    return SingleChildScrollView(
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              imageWidget(_portraitImageSize),
+              messageText,
+            ],
+          ),
+        ),
+    );
+  }
+
+  /// 横向きレイアウト構築メソッド
+ Widget _buildLandscapeLayout(
+      Widget messageText, Widget Function(double) imageWidget) {
     return Center(
-      child: Column(
-        children: [
-          Image.asset(
-            'assets/not_found.png',
-            width: 300,
-            height: 300,
+      child: SingleChildScrollView(
+        child: Padding(
+           padding: EdgeInsets.symmetric(horizontal: (_padding + _landscapeSpacing) * 2),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Flexible(
+                child: imageWidget(_landscapeImageSize),
+              ),
+              const SizedBox(width: _landscapeSpacing),
+              Flexible(
+                child: messageText,
+              ),
+            ],
           ),
-          Text(
-            "該当するリポジトリが見つかりませんでした。\n"
-            "別のキーワードで試してみてください！",
-            style: TextStyle(
-                fontSize: 16,
-                color: theme.textTheme.bodyLarge?.color
-            ),
-            textAlign: TextAlign.center,
-          ),
-        ],
+        ),
       ),
     );
   }
+  
+
+  @override
+  Widget build(BuildContext context) {
+
+    // 共通のテキストウィジェット
+    final messageText = Text(
+      _message,
+      style: Theme.of(context).textTheme.bodyLarge,
+      textAlign: TextAlign.center,
+    );
+
+    // 共通の画像ウィジェット生成関数
+    Widget imageWidget(double size) => Image.asset(
+      'assets/not_found.png',
+      width: size,
+      height: size,
+    );
+
+    return OrientationBuilder(
+      builder: (context, orientation) {
+        return orientation == Orientation.portrait
+            ? _buildPortraitLayout (messageText, imageWidget)// 縦向きレイアウト
+            : _buildLandscapeLayout(messageText, imageWidget);// 横向きレイアウト
+      },
+    );
+  }
+
 }

--- a/lib/widgets/search_controls.dart
+++ b/lib/widgets/search_controls.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:yumemi_coding_test/widgets/sort_option.dart';
+
+/// 検索入力フィールド、検索ボタン、ソートドロップダウンをまとめたウィジェット。
+class SearchControls extends StatelessWidget {
+  final TextEditingController userInputController;
+  final VoidCallback onSearchPressed;
+  final Function(String, bool) onSortSelected;
+  final bool isSortAscending;
+  final String currentSortOption;
+  final bool portraitOrientation;
+
+  const SearchControls({
+    super.key,
+    required this.userInputController,
+    required this.onSearchPressed,
+    required this.onSortSelected,
+    required this.isSortAscending,
+    required this.currentSortOption,
+    required this.portraitOrientation,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        TextField(
+          controller: userInputController,
+          decoration: const InputDecoration(labelText: "リポジトリ名で検索"),
+          onSubmitted: (_) => onSearchPressed(),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Spacer(flex: 3),
+            ElevatedButton(
+              onPressed: onSearchPressed,
+              child: const Text("検索"),
+            ),
+            const Spacer(flex: 2),
+            SortDropdown(
+              onSortSelected: onSortSelected,
+              isSortAscending: isSortAscending,
+              currentSortOption: currentSortOption,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/search_result_view.dart
+++ b/lib/widgets/search_result_view.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+import 'package:yumemi_coding_test/models/repository.dart';
+import 'package:yumemi_coding_test/widgets/empty_result.dart';
+import 'package:yumemi_coding_test/widgets/repository_card.dart';
+
+/// 検索結果リストまたは「結果なし」メッセージを表示するウィジェット。
+class SearchResultView extends StatelessWidget {
+  final List<Repository> repositoryList;
+
+  const SearchResultView({
+    super.key,
+    required this.repositoryList,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // リポジトリリストが空の場合、「結果なし」ウィジェットを表示
+    if (repositoryList.isEmpty) {
+      return const EmptyResultWidget();
+    }
+
+    // リストにデータがある場合、ListView でリポジトリカードを表示
+    return ListView.builder(
+      itemCount: repositoryList.length,
+      itemBuilder: (context, index) {
+        final currentRepository = repositoryList[index];
+        return RepositoryCard(repository: currentRepository);
+      },
+    );
+  }
+}


### PR DESCRIPTION
## 変更理由
デバイスを横向きにした際に、以下の問題が発生していました。

- コンテンツが画面左右いっぱいに広がり、ノッチやジェスチャーエリアなどと重なって見づらくなる。
- 検索結果がない場合に表示される画像とメッセージのレイアウトが縦向きのままで、スペースを有効活用できていない。
- （補足）検索画面でキーボードを表示した際に、入力フィールドなどが隠れてしまう（resizeToAvoidBottomInset の設定漏れ）。

これらの問題を解消し、横画面での操作性と視認性を向上させるために修正を行いました。

## 改善内容
- 横向きレイアウトの最適化:
  * 検索画面・詳細画面・AppBar に左右マージンを追加し、画面端とのスペースを確保しました。
  * 検索結果なし画面で画像とメッセージを横並びに配置しました。
- キーボード表示の調整: 検索画面でキーボード表示時に画面がリサイズされないように設定しました

## 具体的な変更内容
- `screens/search_screen.dart`:
  * 横向き時に AppBar 右端にパディングを追加。
  * 横向き時に Body コンテンツの最大幅を制限し、左右マージンを確保。
キーボード表示時に画面がリサイズされないよう resizeToAvoidBottomInset: false を設定。
- `screens/repository_detail_screen.dart`:
  * 横向き時に Body コンテンツの最大幅を制限し、左右マージンを確保。
- `widgets/empty_result.dart`:
  * 画面の向きに応じてレイアウトを切り替えるように修正。
  * 横向き用のレイアウト（画像とメッセージを Row で表示）を実装。
## 確認方法
- アプリを起動する
- デバイスを横画面にし、以下を確認する
  * 検索画面・詳細画面: コンテンツの左右に適切なマージンが確保されていること。
  * 検索画面: AppBar 右端アイコンの右側にスペースがあること。
  * 検索画面: キーボード表示時にレイアウトが崩れないこと。
  * 検索結果なし画面: 画像とメッセージが横並びで表示されること。
## 関連Issue
#6 